### PR TITLE
feat(config/shell): add default shell configuration for Zsh

### DIFF
--- a/config/shell.lua
+++ b/config/shell.lua
@@ -1,0 +1,6 @@
+return {
+   default_prog = { 'zsh', '-l', '-i' },
+   launch_menu = {
+      { label = 'Zsh with Zinit', args = { 'zsh', '-l', '-i' } },
+   },
+} 

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -17,4 +17,5 @@ return Config:init()
    :append(require('config.domains'))
    :append(require('config.fonts'))
    :append(require('config.general'))
+   :append(require('config.shell'))
    :append(require('config.launch')).options


### PR DESCRIPTION
This pull request introduces a new configuration for the shell setup in the WezTerm terminal emulator. The changes include adding a new `config.shell` module and integrating it into the main configuration.

### Shell configuration:
* [`config/shell.lua`](diffhunk://#diff-2c50ca361dbe2a023a1aa071bbd7bb68d9fb66f0711371d237d417337f8ea4faR1-R6): Added a new configuration file that sets `zsh` as the default program and includes a launch menu option for starting `zsh` with Zinit.

### Integration into main configuration:
* [`wezterm.lua`](diffhunk://#diff-ca68a76bde837819cd11f568261e779d5c053a6aeee5f2eb1cc451338d07170eR20): Integrated the new `config.shell` module into the main configuration pipeline by appending it in the `Config:init()` method.